### PR TITLE
feat: migrate GitHub workflows from PAT to GitHub App authentication

### DIFF
--- a/.github/workflows/auto-merge-dependabot.yml
+++ b/.github/workflows/auto-merge-dependabot.yml
@@ -27,7 +27,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           token: ${{ steps.generate_token.outputs.token }}
-          fetch-depth: 0  # Ensure full history is available for commit
+          fetch-depth: 0 # Ensure full history is available for commit
 
       - name: Comment to trigger Dependabot merge
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           token: ${{ steps.generate_token.outputs.token }}
-          fetch-depth: 0  # Ensure full history is available for commit
+          fetch-depth: 0 # Ensure full history is available for commit
       - name: Setup Java
         uses: actions/setup-java@v4
         with:


### PR DESCRIPTION
## Summary
- Replace Personal Access Token (PAT) with GitHub App tokens in CI workflows
- Update Dependabot auto-merge workflow to use GitHub App authentication
- Add automatic Spotless code formatting job to CI workflow
- Fix missing checkout step in auto-merge workflow for proper gh CLI access

## Changes
- `.github/workflows/auto-merge-dependabot.yml`: Migrate to GitHub App tokens and add checkout step
- `.github/workflows/ci.yml`: Add format job with GitHub App authentication and Spotless integration