### PR TITLE
fix: correct GitHub App token repository configuration

### DIFF
--- a/.github/workflows/auto-merge-dependabot.yml
+++ b/.github/workflows/auto-merge-dependabot.yml
@@ -64,7 +64,7 @@ jobs:
 
           # Enable auto-merge
           gh pr merge ${{ github.event.pull_request.number }} --auto
-          
+
           # Add success comment
           gh pr comment ${{ github.event.pull_request.number }} \
             --body "🚀 Auto-merge enabled for this ${{ steps.metadata.outputs.update-type }} update. Will merge once all checks pass."


### PR DESCRIPTION
## Summary
- Fix repository name duplication issue in GitHub App token generation
- Remove --squash option from auto-merge command to use repository default merge strategy
- Add explicit owner parameter for better reliability

## Changes
- Updated `repositories` parameter to use `github.event.repository.name` instead of `github.repository`
- Added explicit `owner` parameter with `github.repository_owner`
- Removed `--squash` flag from `gh pr merge` command

## Test plan
- Verify GitHub App token generation works correctly in workflow runs
- Confirm auto-merge respects repository merge strategy settings