### PR TITLE
ci: migrate GitHub App auth from app-id to client-id

### DIFF
--- a/.github/workflows/auto-merge-dependabot.yml
+++ b/.github/workflows/auto-merge-dependabot.yml
@@ -25,7 +25,7 @@ jobs:
         id: generate_token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ vars.DEV_AUTOMATION_APP_ID }}
+          client-id: ${{ vars.DEV_AUTOMATION_CLIENT_ID }}
           private-key: ${{ secrets.DEV_AUTOMATION_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
           repositories: ${{ github.event.repository.name }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
         id: generate_token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ vars.DEV_AUTOMATION_APP_ID }}
+          client-id: ${{ vars.DEV_AUTOMATION_CLIENT_ID }}
           private-key: ${{ secrets.DEV_AUTOMATION_PRIVATE_KEY }}
 
       - name: Checkout repository


### PR DESCRIPTION
The `app-id` input of `actions/create-github-app-token` is deprecated in
favor of `client-id`. Switch to `client-id` backed by the
`DEV_AUTOMATION_CLIENT_ID` variable distributed from ops-center.

Requires `DEV_AUTOMATION_CLIENT_ID` to be present in this repository
(distributed via ops-center) before merging.

Companion to seijikohara/ops-center#3.