### PR TITLE
chore(deps): update spring boot to 4.1.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,7 +4,7 @@ kotest = "6.2.0"
 kotlin = "2.4.0"
 mockk = "1.14.11"
 spotless = "8.6.0"
-spring-boot = "4.0.6"
+spring-boot = "4.1.0"
 version-catalog-update = "1.1.0"
 
 [libraries]


### PR DESCRIPTION
## Summary

Update Spring Boot from 4.0.6 to 4.1.0 (GA released 2026-06-10).

The Spring Boot BOM and Gradle plugin are version-linked via `SpringBootPlugin.BOM_COORDINATES`, so this single version-catalog change also advances Spring Framework to 7.0.8 and other managed dependencies (Reactor, Micrometer) to their 4.1.0 baselines.

No source changes are required. The application uses only stable WebFlux, functional routing (`coRouter`), and `WebFluxConfigurer` APIs, none of which are affected by the deprecations removed in 4.1 (Derby, layertools, jOOQ, Spring Data JPA bootstrap, Reactor HttpClient proxy defaults).

## Verification

`./gradlew build` — BUILD SUCCESSFUL

- compile (main / test / integrationTest)
- test
- integrationTest
- spotlessCheck
- bootJar